### PR TITLE
Timeline: fix iteration over intervals of decimal size

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -235,10 +235,10 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     for (let i = 0, notches = 0; i < duration; i += timeInterval, notches++) {
       const notch = notchEl.cloneNode() as HTMLElement
       const isPrimary =
-        (Math.round(i * 100) / 100) % primaryLabelInterval === 0 ||
+        (i.toFixed(2) % primaryLabelInterval.toFixed(2) === 0 ||
         (primaryLabelSpacing && notches % primaryLabelSpacing === 0)
       const isSecondary =
-        (Math.round(i * 100) / 100) % secondaryLabelInterval === 0 ||
+        (i.toFixed(2) % secondaryLabelInterval.toFixed(2) === 0 ||
         (secondaryLabelSpacing && notches % secondaryLabelSpacing === 0)
 
       if (isPrimary || isSecondary) {


### PR DESCRIPTION
## Short description
Resolves #4072

## Implementation details
Uses fixed-point numbers to iterate through intervals to calculate primary and secondary interval correctly

## How to test it
#4072 shows timeline.js example with float intervals, this should fix the issue

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
